### PR TITLE
Enhance weekly analytics storage

### DIFF
--- a/MYON2/MYON2/Models/WeeklyStats.swift
+++ b/MYON2/MYON2/Models/WeeklyStats.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+struct WeeklyStats: Codable, Identifiable {
+    let id: String // week id in YYYY-MM-DD format
+    let workouts: Int
+    let totalSets: Int
+    let totalReps: Int
+    let totalWeight: Double
+    let weightPerMuscleGroup: [String: Double]?
+    let weightPerMuscle: [String: Double]?
+    let repsPerMuscleGroup: [String: Int]?
+    let repsPerMuscle: [String: Int]?
+    let setsPerMuscleGroup: [String: Int]?
+    let setsPerMuscle: [String: Int]?
+    let updatedAt: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case workouts
+        case totalSets = "total_sets"
+        case totalReps = "total_reps"
+        case totalWeight = "total_weight"
+        case weightPerMuscleGroup = "weight_per_muscle_group"
+        case weightPerMuscle = "weight_per_muscle"
+        case repsPerMuscleGroup = "reps_per_muscle_group"
+        case repsPerMuscle = "reps_per_muscle"
+        case setsPerMuscleGroup = "sets_per_muscle_group"
+        case setsPerMuscle = "sets_per_muscle"
+        case updatedAt = "updated_at"
+    }
+}
+

--- a/MYON2/MYON2/Repositories/AnalyticsRepository.swift
+++ b/MYON2/MYON2/Repositories/AnalyticsRepository.swift
@@ -1,0 +1,14 @@
+import Foundation
+import FirebaseFirestore
+
+class AnalyticsRepository {
+    private let db = Firestore.firestore()
+
+    func getWeeklyStats(userId: String, weekId: String) async throws -> WeeklyStats? {
+        let doc = try await db.collection("users").document(userId)
+            .collection("analytics").collection("weekly_stats")
+            .document(weekId).getDocument()
+        return try doc.data(as: WeeklyStats.self)
+    }
+}
+

--- a/MYON2/MYON2/ViewModels/WeeklyStatsViewModel.swift
+++ b/MYON2/MYON2/ViewModels/WeeklyStatsViewModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+@MainActor
+class WeeklyStatsViewModel: ObservableObject {
+    @Published var stats: WeeklyStats?
+    @Published var isLoading = false
+    @Published var error: Error?
+
+    private let repository = AnalyticsRepository()
+
+    func loadCurrentWeek() async {
+        guard let userId = AuthService.shared.currentUser?.uid else { return }
+        let formatter = DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        let weekId = formatter.string(from: Calendar.current.startOfWeek(for: Date()))
+
+        isLoading = true
+        do {
+            stats = try await repository.getWeeklyStats(userId: userId, weekId: weekId)
+        } catch {
+            self.error = error
+        }
+        isLoading = false
+    }
+}
+
+private extension Calendar {
+    func startOfWeek(for date: Date) -> Date {
+        let components = dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)
+        return self.date(from: components) ?? date
+    }
+}
+

--- a/MYON2/MYON2/Views/Components/DashboardComponents.swift
+++ b/MYON2/MYON2/Views/Components/DashboardComponents.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+// MARK: - Dashboard Stat Row
+struct StatRow: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value)
+                .bold()
+        }
+    }
+}
+
+#if DEBUG
+struct StatRow_Previews: PreviewProvider {
+    static var previews: some View {
+        StatRow(title: "Workouts", value: "5")
+            .previewLayout(.sizeThatFits)
+            .padding()
+    }
+}
+#endif

--- a/MYON2/MYON2/Views/HomeDashboardView.swift
+++ b/MYON2/MYON2/Views/HomeDashboardView.swift
@@ -1,13 +1,28 @@
 import SwiftUI
 
 struct HomeDashboardView: View {
+    @StateObject private var viewModel = WeeklyStatsViewModel()
+
     var body: some View {
         VStack(spacing: 24) {
             Text("Dashboard")
                 .font(.largeTitle).bold()
-            Text("Welcome! Your stats and quick actions will appear here.")
-                .foregroundColor(.secondary)
+
+            if viewModel.isLoading {
+                ProgressView()
+            } else if let stats = viewModel.stats {
+                VStack(spacing: 12) {
+                    StatRow(title: "Workouts", value: "\(stats.workouts)")
+                    StatRow(title: "Total Sets", value: "\(stats.totalSets)")
+                    StatRow(title: "Total Reps", value: "\(stats.totalReps)")
+                    StatRow(title: "Volume", value: String(format: "%.0f kg", stats.totalWeight))
+                }
+            } else {
+                Text("No stats available for this week")
+                    .foregroundColor(.secondary)
+            }
         }
         .padding()
+        .task { await viewModel.loadCurrentWeek() }
     }
-} 
+}

--- a/README.md
+++ b/README.md
@@ -213,8 +213,9 @@ firebase_functions/functions/
 │   ├── query-strengthos-v2.js # New Agent Engine integration
 │   ├── query-strengthos.js    # Legacy API integration
 │   └── delete-session.js      # Session cleanup
-├── triggers/                   # Firestore triggers (1 function)
-│   └── muscle-volume-calculations.js # Auto-calculate analytics
+├── triggers/                   # Firestore triggers (2 files)
+│   ├── muscle-volume-calculations.js # Auto-calculate analytics
+│   └── weekly-analytics.js    # Maintain weekly stats
 ├── auth/                       # Authentication middleware
 │   ├── middleware.js          # Dual auth (Firebase + API keys)
 │   └── exchange-token.js      # Token exchange for GCP
@@ -286,6 +287,22 @@ firebase_functions/functions/
     weightFormat: "kg" | "lbs"
   },
   created_at: timestamp,
+  updated_at: timestamp
+}
+```
+
+// Collection: users/{userId}/analytics/weekly_stats/{weekId}
+{
+  workouts: number,
+  total_sets: number,
+  total_reps: number,
+  total_weight: number,
+  weight_per_muscle_group: object,
+  weight_per_muscle: object,
+  reps_per_muscle_group: object,
+  reps_per_muscle: object,
+  sets_per_muscle_group: object,
+  sets_per_muscle: object,
   updated_at: timestamp
 }
 ```

--- a/firebase_functions/functions/index.js
+++ b/firebase_functions/functions/index.js
@@ -53,11 +53,15 @@ const { queryStrengthOS } = require('./strengthos/query-strengthos');
 const { queryStrengthOSv2 } = require('./strengthos/query-strengthos-v2');
 
 // Firestore Triggers
-const { 
-  onTemplateCreated, 
-  onTemplateUpdated, 
-  onWorkoutCreated 
+const {
+  onTemplateCreated,
+  onTemplateUpdated,
+  onWorkoutCreated
 } = require('./triggers/muscle-volume-calculations');
+const {
+  onWorkoutCompleted,
+  onWorkoutDeleted
+} = require('./triggers/weekly-analytics');
 
 // Export all functions as Firebase HTTPS functions
 exports.health = functions.https.onRequest(health);
@@ -108,3 +112,5 @@ exports.getServiceToken = getServiceToken;
 exports.onTemplateCreated = onTemplateCreated;
 exports.onTemplateUpdated = onTemplateUpdated;
 exports.onWorkoutCreated = onWorkoutCreated;
+exports.onWorkoutCompleted = onWorkoutCompleted;
+exports.onWorkoutDeleted = onWorkoutDeleted;

--- a/firebase_functions/functions/triggers/weekly-analytics.js
+++ b/firebase_functions/functions/triggers/weekly-analytics.js
@@ -1,0 +1,127 @@
+const { onDocumentUpdated, onDocumentDeleted } = require('firebase-functions/v2/firestore');
+const admin = require('firebase-admin');
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+const db = admin.firestore();
+
+function getWeekStart(dateString) {
+  const date = new Date(dateString);
+  const day = date.getUTCDay();
+  const diff = (day + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - diff);
+  date.setUTCHours(0, 0, 0, 0);
+  return date.toISOString().split('T')[0];
+}
+
+function mergeMetrics(target = {}, source = {}, increment = 1) {
+  for (const [key, value] of Object.entries(source)) {
+    const current = target[key] || 0;
+    const updated = current + value * increment;
+    if (updated === 0) {
+      delete target[key];
+    } else {
+      target[key] = updated;
+    }
+  }
+}
+
+async function updateWeeklyStats(userId, weekId, analytics, increment = 1) {
+  const ref = db
+    .collection('users')
+    .doc(userId)
+    .collection('analytics')
+    .collection('weekly_stats')
+    .doc(weekId);
+
+  await db.runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    const data = snap.exists
+      ? snap.data()
+      : {
+          workouts: 0,
+          total_sets: 0,
+          total_reps: 0,
+          total_weight: 0,
+          weight_per_muscle_group: {},
+          weight_per_muscle: {},
+          reps_per_muscle_group: {},
+          reps_per_muscle: {},
+          sets_per_muscle_group: {},
+          sets_per_muscle: {},
+        };
+
+    data.workouts += increment;
+    data.total_sets +=
+      (analytics.total_sets || analytics.totalSets || 0) * increment;
+    data.total_reps +=
+      (analytics.total_reps || analytics.totalReps || 0) * increment;
+    data.total_weight +=
+      (analytics.total_weight || analytics.totalWeight || 0) * increment;
+
+    mergeMetrics(
+      data.weight_per_muscle_group,
+      analytics.weight_per_muscle_group || analytics.weightPerMuscleGroup || {},
+      increment
+    );
+    mergeMetrics(
+      data.weight_per_muscle,
+      analytics.weight_per_muscle || analytics.weightPerMuscle || {},
+      increment
+    );
+    mergeMetrics(
+      data.reps_per_muscle_group,
+      analytics.reps_per_muscle_group || analytics.repsPerMuscleGroup || {},
+      increment
+    );
+    mergeMetrics(
+      data.reps_per_muscle,
+      analytics.reps_per_muscle || analytics.repsPerMuscle || {},
+      increment
+    );
+    mergeMetrics(
+      data.sets_per_muscle_group,
+      analytics.sets_per_muscle_group || analytics.setsPerMuscleGroup || {},
+      increment
+    );
+    mergeMetrics(
+      data.sets_per_muscle,
+      analytics.sets_per_muscle || analytics.setsPerMuscle || {},
+      increment
+    );
+
+    data.updated_at = admin.firestore.FieldValue.serverTimestamp();
+    tx.set(ref, data, { merge: true });
+  });
+}
+
+exports.onWorkoutCompleted = onDocumentUpdated(
+  'users/{userId}/workouts/{workoutId}',
+  async (event) => {
+    const before = event.data.before.data();
+    const after = event.data.after.data();
+    if (!after || !after.completedAt) return null;
+    if (before && before.completedAt === after.completedAt) return null;
+
+    const analytics = after.analytics;
+    if (!analytics) return null;
+
+    const weekId = getWeekStart(after.completedAt);
+    await updateWeeklyStats(event.params.userId, weekId, analytics, 1);
+    return { success: true, weekId };
+  }
+);
+
+exports.onWorkoutDeleted = onDocumentDeleted(
+  'users/{userId}/workouts/{workoutId}',
+  async (event) => {
+    const workout = event.data.data();
+    if (!workout || !workout.completedAt || !workout.analytics) return null;
+    const weekId = getWeekStart(workout.completedAt);
+    await updateWeeklyStats(event.params.userId, weekId, workout.analytics, -1);
+    return { success: true, weekId };
+  }
+);
+

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,0 +1,15 @@
+This update introduces a weekly analytics engine and dashboard integration.
+
+**Backend**
+- New `weekly-analytics.js` trigger aggregates workout metrics each time a workout is completed or deleted.
+- Weekly stats are stored under `users/{userId}/analytics/weekly_stats/{weekId}`.
+- `index.js` exports the new trigger functions.
+
+**iOS App**
+- Added `WeeklyStats` model plus `AnalyticsRepository` and `WeeklyStatsViewModel` for loading stats.
+- Moved `StatRow` into `DashboardComponents.swift` and updated `HomeDashboardView` to display weekly totals.
+
+**Documentation**
+- `README.md` now lists the new trigger file and documents the weekly stats collection schema.
+
+Run `make test` in `adk_agent/strengthos-v2` to execute unit and integration tests.


### PR DESCRIPTION
## Summary
- aggregate muscle-level metrics in `weekly-analytics.js`
- store weekly stats under `users/{userId}/analytics/weekly_stats/{weekId}`
- expand `WeeklyStats` model to include muscle group metrics
- fetch weekly stats from new collection path
- move `StatRow` dashboard component to its own file
- document triggers and weekly stats collection in README

## Testing
- `make test` *(fails: DefaultCredentialsError)*

------
https://chatgpt.com/codex/tasks/task_e_685fe960f1608322ad47a9ddb948f332